### PR TITLE
Add MongoID validation to databaseService

### DIFF
--- a/project/assets/database/locales/server/en.json
+++ b/project/assets/database/locales/server/en.json
@@ -66,6 +66,7 @@
     "customisation-unable_to_find_suit_with_id": "Unable to find suit with offer id: %s",
     "customisation-unable_to_get_trader_suits": "Unable to get suits from trader: %s",
     "database-data_at_path_missing": "The database was unable to retrieve data from: [%s] Please ensure your configs are valid and the data at the location exists",
+    "database-invalid_data": "Invalid data detected in database, please remove any outdated mods. See previous error for invalid data. Server stopped.",
     "database-no_location_found_with_id": "No location found with an Id of: %s in database",
     "database-no_trader_found_with_id": "Unable to find trader: %s in database",
     "dialog-chatbot_id_already_exists": "Chat bot: %s being registered already exists, unable to register bot",

--- a/project/src/servers/HttpServer.ts
+++ b/project/src/servers/HttpServer.ts
@@ -6,11 +6,11 @@ import { ConfigTypes } from "@spt/models/enums/ConfigTypes";
 import { IHttpConfig } from "@spt/models/spt/config/IHttpConfig";
 import { ILogger } from "@spt/models/spt/utils/ILogger";
 import { ConfigServer } from "@spt/servers/ConfigServer";
-import { DatabaseServer } from "@spt/servers/DatabaseServer";
 import { WebSocketServer } from "@spt/servers/WebSocketServer";
 import { IHttpListener } from "@spt/servers/http/IHttpListener";
 import { LocalisationService } from "@spt/services/LocalisationService";
 import { inject, injectAll, injectable } from "tsyringe";
+import { DatabaseService } from "@spt/services/DatabaseService";
 
 @injectable()
 export class HttpServer {
@@ -19,7 +19,7 @@ export class HttpServer {
 
     constructor(
         @inject("PrimaryLogger") protected logger: ILogger,
-        @inject("DatabaseServer") protected databaseServer: DatabaseServer,
+        @inject("DatabaseService") protected databaseService: DatabaseService,
         @inject("HttpServerHelper") protected httpServerHelper: HttpServerHelper,
         @inject("LocalisationService") protected localisationService: LocalisationService,
         @injectAll("HttpListener") protected httpListeners: IHttpListener[],
@@ -35,6 +35,12 @@ export class HttpServer {
      */
     public load(): void {
         this.started = false;
+
+        // If the database couldn't be validated, don't start the server
+        if (!this.databaseService.isDatabaseValid())
+        {
+            return;
+        }
 
         /* create server */
         const httpServer: Server = http.createServer();

--- a/project/src/services/PostDbLoadService.ts
+++ b/project/src/services/PostDbLoadService.ts
@@ -57,6 +57,15 @@ export class PostDbLoadService {
         // add items gets left out,causing warnings
         this.itemBaseClassService.hydrateItemBaseClassCache();
 
+        // Validate that only mongoIds exist in items, quests, and traders
+        // Kill the startup if not.
+        // TODO: We can probably remove this in a couple versions
+        this.databaseService.validateDatabase();
+        if (!this.databaseService.isDatabaseValid())
+        {
+            return;
+        }
+
         this.addCustomLooseLootPositions();
 
         this.adjustMinReserveRaiderSpawnChance();

--- a/project/src/utils/App.ts
+++ b/project/src/utils/App.ts
@@ -10,6 +10,7 @@ import { LocalisationService } from "@spt/services/LocalisationService";
 import { EncodingUtil } from "@spt/utils/EncodingUtil";
 import { TimeUtil } from "@spt/utils/TimeUtil";
 import { inject, injectAll, injectable } from "tsyringe";
+import { DatabaseService } from "@spt/services/DatabaseService";
 
 @injectable()
 export class App {
@@ -23,6 +24,7 @@ export class App {
         @inject("ConfigServer") protected configServer: ConfigServer,
         @inject("EncodingUtil") protected encodingUtil: EncodingUtil,
         @inject("HttpServer") protected httpServer: HttpServer,
+        @inject("DatabaseService") protected databaseService: DatabaseService,
         @injectAll("OnLoad") protected onLoadComponents: OnLoad[],
         @injectAll("OnUpdate") protected onUpdateComponents: OnUpdate[],
     ) {
@@ -58,7 +60,7 @@ export class App {
 
     protected async update(onUpdateComponents: OnUpdate[]): Promise<void> {
         // If the server has failed to start, skip any update calls
-        if (!this.httpServer.isStarted()) {
+        if (!this.httpServer.isStarted() || !this.databaseService.isDatabaseValid()) {
             return;
         }
 


### PR DESCRIPTION
- Validate that quests, traders, items and customizations all have MongoID IDs
- If any validation fails, output an error and stop server startup