### PR TITLE
Further favorite item/weapon functionality and fixes

### DIFF
--- a/project/src/controllers/InventoryController.ts
+++ b/project/src/controllers/InventoryController.ts
@@ -928,24 +928,17 @@ export class InventoryController {
     }
 
     public setFavoriteItem(pmcData: IPmcData, request: ISetFavoriteItems, sessionId: string): void {
-        if (!pmcData.Inventory.favoriteItems) {
-            pmcData.Inventory.favoriteItems = [];
-        }
+        // The client sends the full list of favorite items, so clear the current favorites
+        pmcData.Inventory.favoriteItems = [];
 
         for (const itemId of request.items) {
-            // If id already exists in array, we're removing it
-            const indexOfItemAlreadyFavorited = pmcData.Inventory.favoriteItems.findIndex((x) => x._id === itemId);
-            if (indexOfItemAlreadyFavorited > -1) {
-                pmcData.Inventory.favoriteItems.splice(indexOfItemAlreadyFavorited, 1);
-            } else {
-                const item = pmcData.Inventory.items.find((i) => i._id === itemId);
-
-                if (item === undefined) {
-                    continue;
-                }
-
-                pmcData.Inventory.favoriteItems.push(item);
+            // Leaving this in as validation that the item exists in the profile
+            const item = pmcData.Inventory.items.find((i) => i._id === itemId);
+            if (item === undefined) {
+                continue;
             }
+
+            pmcData.Inventory.favoriteItems.push(itemId);
         }
     }
 

--- a/project/src/controllers/ProfileController.ts
+++ b/project/src/controllers/ProfileController.ts
@@ -401,6 +401,9 @@ export class ProfileController {
         return response;
     }
 
+    /**
+     * Handle client/profile/view
+     */
     public getOtherProfile(sessionId: string, request: IGetOtherProfileRequest): IGetOtherProfileResponse {
         const player = this.profileHelper.getFullProfile(sessionId);
         const playerPmc = player.characters.pmc;
@@ -432,7 +435,7 @@ export class ProfileController {
                 Items: playerPmc.Inventory.items,
             },
             achievements: playerPmc.Achievements,
-            favoriteItems: playerPmc.Inventory.favoriteItems ?? [],
+            favoriteItems: this.profileHelper.getOtherProfileFavorites(playerPmc),
             pmcStats: {
                 eft: {
                     totalInGameTime: playerPmc.Stats.Eft.TotalInGameTime,

--- a/project/src/helpers/ProfileHelper.ts
+++ b/project/src/helpers/ProfileHelper.ts
@@ -533,4 +533,29 @@ export class ProfileHelper {
     public getQuestItemsInProfile(profile: IPmcData): IItem[] {
         return profile.Inventory.items.filter((item) => item.parentId === profile.Inventory.questRaidItems);
     }
+
+    /**
+     * Return a favorites array in the format expected by the getOtherProfile call
+     * @param profile 
+     * @returns An array of IItem objects representing the favorited data
+     */
+    public getOtherProfileFavorites(profile: IPmcData): IItem[] {
+        let fullFavorites = [];
+
+        for (const itemId of profile.Inventory.favoriteItems ?? [])
+        {
+            // When viewing another users profile, the client expects a full item with children, so get that
+            const itemAndChildren = this.itemHelper.findAndReturnChildrenAsItems(profile.Inventory.items, itemId);
+            if (itemAndChildren && itemAndChildren.length > 0)
+            {
+                // To get the client to actually see the items, we set the main item's parent to null, so it's treated as a root item
+                const clonedItems = this.cloner.clone(itemAndChildren);
+                clonedItems[0].parentId = null;
+
+                fullFavorites = fullFavorites.concat(clonedItems);
+            }
+        }
+
+        return fullFavorites;
+    }
 }

--- a/project/src/models/eft/common/tables/IBotBase.ts
+++ b/project/src/models/eft/common/tables/IBotBase.ts
@@ -169,7 +169,7 @@ export interface IInventory {
     /** Key is hideout area enum numeric as string e.g. "24", value is area _id  */
     hideoutAreaStashes: Record<string, string>;
     fastPanel: Record<string, string>;
-    favoriteItems: IItem[];
+    favoriteItems: string[];
 }
 
 export interface IBaseJsonSkills {

--- a/project/src/services/ProfileFixerService.ts
+++ b/project/src/services/ProfileFixerService.ts
@@ -64,6 +64,7 @@ export class ProfileFixerService {
         this.removeDanglingTaskConditionCounters(pmcProfile);
         this.removeOrphanedQuests(pmcProfile);
         this.verifyQuestProductionUnlocks(pmcProfile);
+        this.fixFavorites(pmcProfile);
 
         if (pmcProfile.Hideout) {
             this.addHideoutEliteSlots(pmcProfile);
@@ -338,6 +339,23 @@ export class ProfileFixerService {
             this.logger.debug(
                 `Added production ${matchingProductionId} to unlocked production recipes for ${questDetails.QuestName}`,
             );
+        }
+    }
+
+    /**
+     * Initial release of SPT 3.10 used an incorrect favorites structure, reformat
+     * the structure to the correct MongoID array structure
+     * @param pmcProfile 
+     */
+    protected fixFavorites(pmcProfile: IPmcData): void {
+        const favoritesAsAny = pmcProfile.Inventory?.favoriteItems as any;
+        if (favoritesAsAny)
+        {
+            const correctedFavorites = favoritesAsAny.map((favorite) => {
+                return favorite._id ?? favorite;
+            });
+
+            pmcProfile.Inventory.favoriteItems = correctedFavorites ?? [];
         }
     }
 


### PR DESCRIPTION
- Resolve issue where we were storing favorites in the incorrect format, resulting in a client error on game load
- Resolve issue where we were clearing favorites when they were meant to be saved
- On login, fix any previously corrupted favorites array
- Properly implement favorite data in `getOtherProfile`, now shows your favorites when viewing your profile