### PR TITLE
Directly reference equipment id instead of using .find when retrieving other player's profile

### DIFF
--- a/project/src/controllers/ProfileController.ts
+++ b/project/src/controllers/ProfileController.ts
@@ -427,8 +427,7 @@ export class ProfileController {
             },
             skills: playerPmc.Skills,
             equipment: {
-                // Default inventory tpl
-                Id: playerPmc.Inventory.items.find((item) => item._tpl === ItemTpl.INVENTORY_DEFAULT)._id,
+                Id: playerPmc.Inventory.equipment,
                 Items: playerPmc.Inventory.items,
             },
             achievements: playerPmc.Achievements,


### PR DESCRIPTION
This fixes an edge-case where the `.find` could return a gear rack mannequin's equipment instead of the player's if their inventory isn't in the order expected.