### PR TITLE
Cultist Live Tweaks

### DIFF
--- a/project/assets/configs/hideout.json
+++ b/project/assets/configs/hideout.json
@@ -19,16 +19,21 @@
         "craftTimeThreshholds": [
             {
                 "min": 1,
-                "max": 25000,
-                "timeSeconds": 21600
+                "max": 349999,
+                "timeSeconds": 43200
             },
             {
-                "min": 25001,
+                "min": 350000,
+                "max": 399999,
+                "timeSeconds": 50400
+            },
+            {
+                "min": 400000,
                 "max": 99999999,
-                "timeSeconds": 43200
+                "timeSeconds": 50400
             }
         ],
-        "craftTimeOverride": 40,
+        "craftTimeOverride": -1,
         "directRewards": {
             "66572c82ad599021091c6118": { "rewardTpls": ["5c0e874186f7745dc7616606"], "craftTimeSeconds": 3960 },
             "5aa2b986e5b5b00014028f4c": { "rewardTpls": ["62a091170b9d3c46de5b6cf2"], "craftTimeSeconds": 3960 },

--- a/project/assets/configs/hideout.json
+++ b/project/assets/configs/hideout.json
@@ -18,6 +18,7 @@
         },
         "bonusChance": 0.25,
         "bonusAmount": 0.43,
+        "highValueThreshold": 70000,
         "craftTimeThreshholds": [
             {
                 "min": 1,

--- a/project/assets/configs/hideout.json
+++ b/project/assets/configs/hideout.json
@@ -16,6 +16,8 @@
             "min": 0.7,
             "max": 1.4
         },
+        "bonusChance": 0.25,
+        "bonusAmount": 0.43,
         "craftTimeThreshholds": [
             {
                 "min": 1,

--- a/project/assets/configs/hideout.json
+++ b/project/assets/configs/hideout.json
@@ -20,17 +20,17 @@
             {
                 "min": 1,
                 "max": 349999,
-                "timeSeconds": 43200
+                "craftTimeSeconds": 43200
             },
             {
                 "min": 350000,
                 "max": 399999,
-                "timeSeconds": 50400
+                "craftTimeSeconds": 50400
             },
             {
                 "min": 400000,
                 "max": 99999999,
-                "timeSeconds": 50400
+                "craftTimeSeconds": 50400
             }
         ],
         "craftTimeOverride": -1,

--- a/project/src/helpers/ItemHelper.ts
+++ b/project/src/helpers/ItemHelper.ts
@@ -1812,11 +1812,8 @@ export class ItemHelper {
      */
     public getRandomItem(blacklist: String[]): ITemplateItem {
         const allItems = this.getItems();
-        for (const item of allItems) {
-            if (!blacklist.includes(item._id)) {
-                return item;
-            }
-        }
+        const filteredItem = allItems.filter((item) => !blacklist.includes(item._id));
+        return filteredItem[Math.floor(Math.random() * allItems.length)];
     }
 }
 

--- a/project/src/helpers/ItemHelper.ts
+++ b/project/src/helpers/ItemHelper.ts
@@ -1804,6 +1804,20 @@ export class ItemHelper {
             delete item.upd.SpawnedInSession;
         }
     }
+
+    /**
+     * Return a random item from items.json while respecting a blacklist
+     * @param blacklist Items to not return
+     * @returns random item from items.json
+     */
+    public getRandomItem(blacklist: String[]): ITemplateItem {
+        const allItems = this.getItems();
+        for (const item of allItems) {
+            if (!blacklist.includes(item._id)) {
+                return item;
+            }
+        }
+    }
 }
 
 namespace ItemHelper {

--- a/project/src/models/spt/config/IHideoutConfig.ts
+++ b/project/src/models/spt/config/IHideoutConfig.ts
@@ -23,6 +23,8 @@ export interface ICultistCircleSettings {
     /** The odds that meeting the highest threshold gives you a bonus to crafting time */
     bonusAmount: number;
     bonusChance: number;
+    /** What is considered a "high-value" item */
+    highValueThreshold: number;
     craftTimeThreshholds: ICraftTimeThreshhold[];
     /** -1 means no override */
     craftTimeOverride: number;

--- a/project/src/models/spt/config/IHideoutConfig.ts
+++ b/project/src/models/spt/config/IHideoutConfig.ts
@@ -20,6 +20,9 @@ export interface ICultistCircleSettings {
     maxRewardItemCount: number;
     maxAttemptsToPickRewardsWithinBudget: number;
     rewardPriceMultiplerMinMax: MinMax;
+    /** The odds that meeting the highest threshold gives you a bonus to crafting time */
+    bonusAmount: number;
+    bonusChance: number;
     craftTimeThreshholds: ICraftTimeThreshhold[];
     /** -1 means no override */
     craftTimeOverride: number;

--- a/project/src/services/CircleOfCultistService.ts
+++ b/project/src/services/CircleOfCultistService.ts
@@ -222,10 +222,10 @@ export class CircleOfCultistService {
 
         // If no threshold fits
         if (!matchingThreshold) {
-            // Sanity check that thresholds exist, if not use 12 hours. Otherwise use the first set.
+            // Sanity check that thresholds exist, if not use 12 hours. Otherwise, use the first set.
             let fallbackThreshold = 43200;
-            if (thresholds[0] && thresholds[0].timeSeconds) {
-                fallbackThreshold = thresholds[0].timeSeconds;
+            if (thresholds[0] && thresholds[0].craftTimeSeconds) {
+                fallbackThreshold = thresholds[0].craftTimeSeconds;
             }
             return fallbackThreshold;
         }
@@ -234,8 +234,8 @@ export class CircleOfCultistService {
         const minThresholds = thresholds.map((a) => a.min)
         const highestThresholdMin = Math.max(...minThresholds);
         if (rewardAmountRoubles >= highestThresholdMin && Math.random() <= 0.25) {
-            const highestThreshold = thresholds.filter(thresholds => thresholds.min === highestThresholdMin)
-            return Math.round(highestThreshold.timeSeconds * 0.43);
+            const highestThreshold = thresholds.filter(thresholds => thresholds.min === highestThresholdMin)[0];
+            return Math.round(highestThreshold.craftTimeSeconds * 0.43);
         }
 
         return matchingThreshold.craftTimeSeconds;

--- a/project/src/services/CircleOfCultistService.ts
+++ b/project/src/services/CircleOfCultistService.ts
@@ -174,7 +174,6 @@ export class CircleOfCultistService {
      * @param sacrificedItems Items player sacrificed
      * @param rewardAmountRoubles Rouble amount to reward player in items with
      * @param craftingTime How long the ritual should take
-     * @param directRewardSettings OPTIONAL: If craft is giving direct rewards
      */
     protected registerCircleOfCultistProduction(
         sessionId: string,
@@ -183,7 +182,6 @@ export class CircleOfCultistService {
         sacrificedItems: IItem[],
         rewardAmountRoubles: number,
         craftingTime: number,
-        directRewardSettings?: IDirectRewardSettings,
     ): void {
         // Create circle production/craft object to add to player profile
         const cultistProduction = this.hideoutHelper.initProduction(
@@ -369,8 +367,8 @@ export class CircleOfCultistService {
     }
 
     /**
-     * Give every item as a reward that's passed in
-     * @param rewardTpls Item tpls to turn into reward items
+     * Get explicit rewards
+     * @param explicitRewardSettings Item tpls to turn into reward items
      * @param cultistCircleStashId Id of stash item
      * @returns Array of item arrays
      */
@@ -608,12 +606,7 @@ export class CircleOfCultistService {
      */
     protected getPlayerAccessibleHideoutAreas(areas: IBotHideoutArea[]): IBotHideoutArea[] {
         return areas.filter((area) => {
-            if (area.type === HideoutAreas.CHRISTMAS_TREE && !this.seasonalEventService.christmasEventEnabled()) {
-                // Christmas tree area and not Christmas, skip
-                return false;
-            }
-
-            return true;
+            return !(area.type === HideoutAreas.CHRISTMAS_TREE && !this.seasonalEventService.christmasEventEnabled());
         });
     }
 

--- a/project/src/services/CircleOfCultistService.ts
+++ b/project/src/services/CircleOfCultistService.ts
@@ -235,7 +235,7 @@ export class CircleOfCultistService {
         const highestThresholdMin = Math.max(...minThresholds);
         if (rewardAmountRoubles >= highestThresholdMin && Math.random() <= 0.25) {
             const highestThreshold = thresholds.filter(thresholds => thresholds.min === highestThresholdMin)
-            return Math.round(highestThreshold * 0.43);
+            return Math.round(highestThreshold.timeSeconds * 0.43);
         }
 
         return matchingThreshold.craftTimeSeconds;

--- a/project/src/services/CircleOfCultistService.ts
+++ b/project/src/services/CircleOfCultistService.ts
@@ -233,9 +233,9 @@ export class CircleOfCultistService {
         // Handle 25% chance if over the highest min threshold for a shorter timer. Live is ~0.43 of the base threshold.
         const minThresholds = thresholds.map((a) => a.min)
         const highestThresholdMin = Math.max(...minThresholds);
-        if (rewardAmountRoubles >= highestThresholdMin && Math.random() <= 0.25) {
+        if (rewardAmountRoubles >= highestThresholdMin && Math.random() <= this.hideoutConfig.cultistCircle.bonusChance) {
             const highestThreshold = thresholds.filter(thresholds => thresholds.min === highestThresholdMin)[0];
-            return Math.round(highestThreshold.craftTimeSeconds * 0.43);
+            return Math.round(highestThreshold.craftTimeSeconds * this.hideoutConfig.cultistCircle.bonusAmount);
         }
 
         return matchingThreshold.craftTimeSeconds;


### PR DESCRIPTION
Referencing https://escapefromtarkov.fandom.com/wiki/Hideout#Cultist_Circle and https://www.cultistcircle.com/


- 3 tiers of bonus (0, 1, 2) with 0 being not getting out of the first threshold, 1 being not the lowest, 2 being the highest that passed a % chance check.
-- Tier 0 gets random crap. Could potentially be good, could be toilet paper
-- Tier 1 is "high-value" loot only, there's now a var in hideout.json to determine the cutoff
-- Tier 2 is hideout/task loot and falls back to high-value if none of those exist
- Ammo/Money/Boss loot is all filtered from the random items
- Removed the hard coded 12 hour fallback when no correct threshold could be found., it will now try to use the first threshold if it exists otherwise then it will use 12 hours.
