### PR TITLE
Vitest Updates

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -66,8 +66,8 @@
         "@types/proper-lockfile": "~4.1",
         "@types/semver": "~7.5",
         "@types/ws": "~8.5",
-        "@vitest/coverage-istanbul": "~2",
-        "@vitest/ui": "~2",
+        "@vitest/coverage-istanbul": "^2.1.8",
+        "@vitest/ui": "^2.1.8",
         "@yao-pkg/pkg": "5.12",
         "@yao-pkg/pkg-fetch": "3.5.9",
         "cross-env": "~7.0",
@@ -81,7 +81,8 @@
         "resedit": "~2.0",
         "ts-node-dev": "~2.0",
         "tsconfig-paths": "~4.2",
-        "typedoc": "~0.26"
+        "typedoc": "~0.26",
+        "vitest": "^2.1.8"
     },
     "targets": {
         "default": {

--- a/project/src/controllers/RepeatableQuestController.ts
+++ b/project/src/controllers/RepeatableQuestController.ts
@@ -578,7 +578,7 @@ export class RepeatableQuestController {
             const charismaBonus = this.profileHelper.getSkillFromProfile(pmcData, SkillTypes.CHARISMA)?.Progress ?? 0;
             for (const cost of previousChangeRequirement.changeCost) {
                 // Not free, Charge player + appy charisma bonus to cost of replacement
-                cost.count = Math.trunc(cost.count * (1 - Math.trunc(charismaBonus / 100) * 0.001) ?? 1);
+                cost.count = Math.trunc(cost.count * (1 - Math.trunc(charismaBonus / 100) * 0.001));
                 this.paymentService.addPaymentToOutput(pmcData, cost.templateId, cost.count, sessionID, output);
                 if (output.warnings.length > 0) {
                     return output;

--- a/project/tests/CustomEnvironment.ts
+++ b/project/tests/CustomEnvironment.ts
@@ -6,7 +6,7 @@ import { IDatabaseTables } from "@spt/models/spt/server/IDatabaseTables";
 import { DatabaseServer } from "@spt/servers/DatabaseServer";
 import { ImporterUtil } from "@spt/utils/ImporterUtil";
 import { DependencyContainer, Lifecycle, container } from "tsyringe";
-import type { Environment } from "vitest";
+import type { Environment } from "vitest/environments";
 
 // Manually mock the logger.
 import { WinstonLogger } from "@tests/__mocks__/WinstonLogger.mock";
@@ -26,7 +26,7 @@ export default (<Environment>{
         await importDatabase(container);
 
         return {
-            async teardown() {},
+            async teardown() { },
         };
     },
 });

--- a/project/vitest.config.mts
+++ b/project/vitest.config.mts
@@ -2,12 +2,12 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+    cacheDir: "./tests/__cache__",
     test: {
         name: "spt-server",
         reporters: ["default"],
         root: "./",
         include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-        cache: { dir: "./tests/__cache__" },
         environment: "./tests/CustomEnvironment.ts",
         globals: true,
         coverage: {


### PR DESCRIPTION
Includes updates to Vitest dependencies, a small bug fix, and a configuration change. All three of which were throwing warnings when the test suite was ran.

### Dependency Updates:
* [`project/package.json`](diffhunk://#diff-18e5b8a4dad7b1ed0da6b50ed507b3ab8116e07a8e44abd959a28261878d021fL69-R70): Updated `@vitest/coverage-istanbul` and `@vitest/ui` to version `^2.1.8` and added `vitest` dependency. [[1]](diffhunk://#diff-18e5b8a4dad7b1ed0da6b50ed507b3ab8116e07a8e44abd959a28261878d021fL69-R70) [[2]](diffhunk://#diff-18e5b8a4dad7b1ed0da6b50ed507b3ab8116e07a8e44abd959a28261878d021fL84-R85)

### Bug Fix:
* [`project/src/controllers/RepeatableQuestController.ts`](diffhunk://#diff-92e6bd4234ed3c13309eb9bd27437f0933e58dedee51544e9b017b57c2a3c51cL581-R581): Fixed a bug in the charisma bonus calculation for the `cost.count` value.

### Configuration Changes:
* [`project/tests/CustomEnvironment.ts`](diffhunk://#diff-79780538b7a90a5f7befb22838a460f65e3e0bce53d3685f36ed2b74894246a0L9-R9): Updated the import path for `Environment` from `vitest`.
* [`project/vitest.config.mts`](diffhunk://#diff-18152746ad4df10b798ca21a09c321bc8ad4adc393ebc6a26016a524203e599cR5-L10): Added `cacheDir` configuration and renamed the file from `vitest.config.ts`.