### PR TITLE
Database Import Progress Bar

### DIFF
--- a/project/src/utils/ImporterUtil.ts
+++ b/project/src/utils/ImporterUtil.ts
@@ -1,4 +1,5 @@
 import { JsonUtil } from "@spt/utils/JsonUtil";
+import { ProgressWriter } from "@spt/utils/ProgressWriter";
 import { VFS } from "@spt/utils/VFS";
 import { Queue } from "@spt/utils/collections/queue/Queue";
 import { inject, injectable } from "tsyringe";
@@ -119,9 +120,12 @@ export class ImporterUtil {
             directoriesToRead.enqueueAll(this.vfs.getDirs(directory).map((d) => `${directory}/${d}`));
         }
 
+        const progressWriter = new ProgressWriter(filesToProcess.length);
+
         while (filesToProcess.length !== 0) {
             const fileNode = filesToProcess.dequeue();
             if (!fileNode) continue;
+
             if (this.vfs.getFileExtension(fileNode.fileName) === "json") {
                 const filePathAndName = `${fileNode.filePath}${fileNode.fileName}`;
                 promises.push(
@@ -135,7 +139,8 @@ export class ImporterUtil {
                             onObjectDeserialized(filePathAndName, fileDeserialized);
                             const strippedFilePath = this.vfs.stripExtension(filePathAndName).replace(filepath, "");
                             this.placeObject(fileDeserialized, strippedFilePath, result, strippablePath);
-                        }),
+                        })
+                        .then(() => progressWriter.increment()),
                 );
             }
         }

--- a/project/src/utils/ProgressWriter.ts
+++ b/project/src/utils/ProgressWriter.ts
@@ -4,9 +4,22 @@ export class ProgressWriter {
     private count = 0;
     private total?: number;
     private done = false;
+    private barFillChar: string;
+    private barEmptyChar: string;
+    private maxBarLength: number;
 
-    constructor(total: number) {
+    constructor(total: number, maxBarLength = 25, barFillChar = "\u25A0", barEmptyChar = " ") {
+        if (total <= 0) {
+            throw new Error("Total must be a positive number.");
+        }
+        if ((barFillChar && barFillChar.length !== 1) || (barEmptyChar && barEmptyChar.length !== 1)) {
+            throw new Error("Bar character values must be a single character.");
+        }
+
         this.total = total;
+        this.maxBarLength = maxBarLength;
+        this.barFillChar = barFillChar;
+        this.barEmptyChar = barEmptyChar;
     }
 
     /**
@@ -20,12 +33,11 @@ export class ProgressWriter {
         this.count++;
 
         const progress = Math.floor((this.count / this.total) * 100);
+        const filledChars = Math.floor((progress / 100) * this.maxBarLength);
+        const emptyChars = this.maxBarLength - filledChars;
 
-        // reduce bar fill max to 50 characters to save space
-        const progressHalved = Math.floor(progress / 4);
-
-        const barFill = "=".repeat(progressHalved);
-        const barEmptySpace = " ".repeat(Math.floor(25 - progressHalved));
+        const barFill = this.barFillChar.repeat(filledChars);
+        const barEmptySpace = this.barEmptyChar.repeat(emptyChars);
 
         const progressBar = `  -> ${this.count} / ${this.total} [${barFill}${barEmptySpace}] ${progress}%`;
 

--- a/project/src/utils/ProgressWriter.ts
+++ b/project/src/utils/ProgressWriter.ts
@@ -1,0 +1,35 @@
+export class ProgressWriter {
+    count = 0;
+    total: number;
+    done = false;
+
+    constructor(total: number) {
+        this.total = total;
+    }
+
+    public increment(): void {
+        if (this.done) {
+            return;
+        }
+
+        this.count++;
+
+        const progress = Math.floor((this.count / this.total) * 100);
+
+        // reduce bar fill max to 50 characters to save space
+        const progressHalved = Math.floor(progress / 4);
+
+        const barFill = "=".repeat(progressHalved);
+        const barEmptySpace = " ".repeat(Math.floor(25 - progressHalved));
+
+        const progressBar = `  -> ${this.count} / ${this.total} [${barFill}${barEmptySpace}] ${progress}%`;
+
+        process.stdout.write(progressBar);
+        process.stdout.cursorTo(0);
+
+        if (progress === 100) {
+            process.stdout.write("\n");
+            this.done = true;
+        }
+    }
+}

--- a/project/src/utils/ProgressWriter.ts
+++ b/project/src/utils/ProgressWriter.ts
@@ -1,14 +1,17 @@
 import * as readline from "node:readline";
 
 export class ProgressWriter {
-    count = 0;
-    total: number;
-    done = false;
+    private count = 0;
+    private total?: number;
+    private done = false;
 
     constructor(total: number) {
         this.total = total;
     }
 
+    /**
+     * Increment the progress counter and update the progress bar display.
+     */
     public increment(): void {
         if (this.done) {
             return;

--- a/project/src/utils/ProgressWriter.ts
+++ b/project/src/utils/ProgressWriter.ts
@@ -1,3 +1,5 @@
+import * as readline from "node:readline";
+
 export class ProgressWriter {
     count = 0;
     total: number;
@@ -24,8 +26,9 @@ export class ProgressWriter {
 
         const progressBar = `  -> ${this.count} / ${this.total} [${barFill}${barEmptySpace}] ${progress}%`;
 
+        readline.clearLine(process.stdout, 0);
+        readline.cursorTo(process.stdout, 0, null);
         process.stdout.write(progressBar);
-        process.stdout.cursorTo(0);
 
         if (progress === 100) {
             process.stdout.write("\n");


### PR DESCRIPTION
Waffle wrote a PR (#986) that shows a progress bar when the database is populating. I pulled it into a local branch and made some adjustments.

I've tested this on my end and it's working okay. In the compiled project, and directly in terminals (that *I have installed*) it looks great, but in VSCode's built in terminal you can see escape characters at the beginning of the line:

![image](https://github.com/user-attachments/assets/c547a675-5331-44f3-a44e-940edaba6fe8)

I can't figure out why, or how to get rid of it, but it doesn't really bother me much.