### PR TITLE
Fix TerraGroup Employee start conditions

### DIFF
--- a/project/assets/database/templates/quests.json
+++ b/project/assets/database/templates/quests.json
@@ -60335,9 +60335,26 @@
           "parentId": "",
           "status": [
             4,
-            5
+            5,
+            7
           ],
           "target": "5edac34d0bb72a50635c2bfa",
+          "visibilityConditions": []
+        },
+        {
+          "availableAfter": 0,
+          "conditionType": "Quest",
+          "dispersion": 0,
+          "dynamicLocale": false,
+          "globalQuestCounterId": "",
+          "id": "677260a62c1ea725720d6532",
+          "index": 1,
+          "parentId": "",
+          "status": [
+            4,
+            5
+          ],
+          "target": "5edab4b1218d181e29451435",
           "visibilityConditions": []
         }
       ],


### PR DESCRIPTION
Added status 7 to prerequisite quest "Colleagues - Part 3" 
Added "The Huntsman Path - Sadist" as prerequisite quest

This change aligns quest behavior to Live PVP. Possible that the dumped PVE data is incorrect. Issue also present in 4.0.0.

"id" and "index" might need to be changed.