### PR TITLE
Adopt orphaned items sent with the mail service

### DIFF
--- a/project/src/services/MailSendService.ts
+++ b/project/src/services/MailSendService.ts
@@ -174,7 +174,10 @@ export class MailSendService {
 
         // Add items to message
         if (items.length > 0) {
-            details.items = items;
+            const rootItemParentID = this.hashUtil.generate();
+
+            details.items = this.itemHelper.adoptOrphanedItems(rootItemParentID, items);
+
             details.itemsMaxStorageLifetimeSeconds = maxStorageTimeSeconds ?? 172800; // 48 hours if no value supplied
         }
 


### PR DESCRIPTION
Sometimes items aren't received properly due to them not being parented correctly in sendSystemMessageToPlayer, this aims to fix that.