### PR TITLE
Fix up edge case error with tiered flea weapon builds

### DIFF
--- a/project/src/helpers/RagfairOfferHelper.ts
+++ b/project/src/helpers/RagfairOfferHelper.ts
@@ -264,6 +264,11 @@ export class RagfairOfferHelper {
                         tieredFleaLimitTypes,
                         pmcData.Info.Level,
                     );
+
+                    // Do not add offer to build if user does not have access to it
+                    if (offer.locked) {
+                        continue;
+                    }
                 }
 
                 const key = offer.items[0]._tpl;


### PR DESCRIPTION
Currently there is an error on the server if certain weapons or weapon parts are selected that the user hasn't unlocked yet but attempts to use for said weapons or parts for a build with the tiered flea, this remedies that by never showing these parts.