### PR TITLE
Node Version Validation

### DIFF
--- a/project/gulpfile.mjs
+++ b/project/gulpfile.mjs
@@ -172,6 +172,7 @@ const writeBuildDataToJSON = async (entryType) => {
 
         const buildInfo = {};
         buildInfo.entryType = entryType;
+        buildInfo.expectedNode = manifest?.engines?.node ?? "";
         buildInfo.sptVersion = coreParsed.sptVersion;
         buildInfo.commit = coreParsed.commit;
         buildInfo.buildTime = coreParsed.buildTime;

--- a/project/src/ProgramStatics.ts
+++ b/project/src/ProgramStatics.ts
@@ -1,4 +1,5 @@
 import buildInfo from "@spt/entry/build.json" assert { type: "json" };
+import fs from "fs-extra";
 import { EntryType } from "./models/enums/EntryType";
 
 // biome-ignore lint/complexity/noStaticOnlyClass:
@@ -9,12 +10,23 @@ export class ProgramStatics {
     private static _COMPILED: boolean;
     private static _MODS: boolean;
 
+    private static _EXPECTED_NODE: string;
     private static _SPT_VERSION: string;
     private static _COMMIT: string;
     private static _BUILD_TIME: number;
 
     public static initialize(): void {
         ProgramStatics._ENTRY_TYPE = buildInfo.entryType as EntryType;
+
+        // If running the local entry, the expected node version can be fetched from the package.json file. In built
+        // entries, the expected node version is set at build and can be fetched from the build.json file.
+        if (ProgramStatics._ENTRY_TYPE === EntryType.LOCAL) {
+            const packageInfo = JSON.parse(fs.readFileSync("./package.json", "utf8"));
+            ProgramStatics._EXPECTED_NODE = packageInfo?.engines?.node ?? "";
+        } else {
+            ProgramStatics._EXPECTED_NODE = buildInfo.expectedNode;
+        }
+
         ProgramStatics._SPT_VERSION = buildInfo.sptVersion ?? "";
         ProgramStatics._COMMIT = buildInfo.commit ?? "";
         ProgramStatics._BUILD_TIME = buildInfo.buildTime ?? 0;
@@ -56,6 +68,9 @@ export class ProgramStatics {
     }
     public static get MODS(): boolean {
         return ProgramStatics._MODS;
+    }
+    public static get EXPECTED_NODE(): string {
+        return ProgramStatics._EXPECTED_NODE;
     }
     public static get SPT_VERSION(): string {
         return ProgramStatics._SPT_VERSION;

--- a/project/src/entry/build.json
+++ b/project/src/entry/build.json
@@ -1,5 +1,6 @@
 {
     "entryType": "LOCAL",
+    "expectedNode": "",
     "sptVersion": "",
     "commit": "",
     "buildTime": 0

--- a/project/src/utils/App.ts
+++ b/project/src/utils/App.ts
@@ -43,6 +43,15 @@ export class App {
         this.logger.debug(`PATH: ${this.encodingUtil.toBase64(process.execPath)}`);
         this.logger.debug(`Server: ${ProgramStatics.SPT_VERSION || this.coreConfig.sptVersion}`);
 
+        const nodeVersion = process.version.replace(/^v/, "");
+        if (ProgramStatics.EXPECTED_NODE && nodeVersion !== ProgramStatics.EXPECTED_NODE) {
+            this.logger.error(
+                `Node version mismatch. Required: ${ProgramStatics.EXPECTED_NODE} | Current: ${nodeVersion}`,
+            );
+            process.exit(1);
+        }
+        this.logger.debug(`Node: ${nodeVersion}`);
+
         if (ProgramStatics.BUILD_TIME) {
             this.logger.debug(`Date: ${ProgramStatics.BUILD_TIME}`);
         }


### PR DESCRIPTION
This introduces a node version validation check on server start-up. The expected node version is pulled from the `package.json`. Locally, the expected version is pulled directly. The build script writes the expected node version into the `build.json` file, which is used in the built environment. When an invalid match is made the server start-up halts.