### PR TITLE
Fully make loadAsync asynchronous

### DIFF
--- a/project/src/utils/DatabaseImporter.ts
+++ b/project/src/utils/DatabaseImporter.ts
@@ -85,7 +85,7 @@ export class DatabaseImporter implements OnLoad {
         const dataToImport = await this.importerUtil.loadAsync<IDatabaseTables>(
             `${filepath}database/`,
             this.filepath,
-            (fileWithPath: string, data: string) => this.onReadValidate(fileWithPath, data),
+            async (fileWithPath: string, data: string) => await this.onReadValidate(fileWithPath, data),
         );
 
         const validation =
@@ -94,9 +94,9 @@ export class DatabaseImporter implements OnLoad {
         this.databaseServer.setTables(dataToImport);
     }
 
-    protected onReadValidate(fileWithPath: string, data: string): void {
+    protected async onReadValidate(fileWithPath: string, data: string): Promise<void> {
         // Validate files
-        if (ProgramStatics.COMPILED && this.hashedFile && !this.validateFile(fileWithPath, data)) {
+        if (ProgramStatics.COMPILED && this.hashedFile && !(await this.validateFile(fileWithPath, data))) {
             this.valid = VaildationResult.FAILED;
         }
     }
@@ -105,7 +105,7 @@ export class DatabaseImporter implements OnLoad {
         return "spt-database";
     }
 
-    protected validateFile(filePathAndName: string, fileData: any): boolean {
+    protected async validateFile(filePathAndName: string, fileData: any): Promise<boolean> {
         try {
             const finalPath = filePathAndName.replace(this.filepath, "").replace(".json", "");
             let tempObject: any;
@@ -117,7 +117,7 @@ export class DatabaseImporter implements OnLoad {
                 }
             }
 
-            if (tempObject !== this.hashUtil.generateSha1ForData(fileData)) {
+            if (tempObject !== (await this.hashUtil.generateSha1ForDataAsync(fileData))) {
                 this.logger.debug(this.localisationService.getText("validation_error_file", filePathAndName));
                 return false;
             }

--- a/project/src/utils/HashUtil.ts
+++ b/project/src/utils/HashUtil.ts
@@ -1,4 +1,4 @@
-import crypto from "node:crypto";
+import crypto, { webcrypto } from "node:crypto";
 import { TimeUtil } from "@spt/utils/TimeUtil";
 import crc32 from "buffer-crc32";
 import { mongoid } from "mongoid-js";
@@ -40,7 +40,6 @@ export class HashUtil {
     public generateCRC32ForFile(filePath: string): number {
         return crc32.unsigned(this.fileSystemSync.read(filePath));
     }
-
     /**
      * Create a hash for the data parameter
      * @param algorithm algorithm to use to hash
@@ -51,6 +50,18 @@ export class HashUtil {
         const hashSum = crypto.createHash(algorithm);
         hashSum.update(data);
         return hashSum.digest("hex");
+    }
+
+    /** Creates a SHA-1 hash asynchronously, this doesn't end up blocking.
+     * @param data data to be hashed
+     * @returns A promise with the hash value
+     */
+    public async generateSha1ForDataAsync(data: crypto.BinaryLike): Promise<string> {
+        const encoder = new TextEncoder();
+        const encodedData = encoder.encode(data.toString());
+
+        const hashBuffer = await webcrypto.subtle.digest("SHA-1", encodedData);
+        return [...new Uint8Array(hashBuffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
     }
 
     public generateAccountId(): number {

--- a/project/src/utils/ImporterUtil.ts
+++ b/project/src/utils/ImporterUtil.ts
@@ -25,7 +25,7 @@ export class ImporterUtil {
             try {
                 const fileData = await this.fileSystem.read(file);
                 await onReadCallback(file, fileData);
-                const fileDeserialized = await this.jsonUtil.deserializeWithCacheCheckAsync<any>(fileData, file, false);
+                const fileDeserialized = await this.jsonUtil.deserializeWithCacheCheck<any>(fileData, file, false);
                 await onObjectDeserialized(file, fileDeserialized);
                 const strippedFilePath = FileSystem.stripExtension(file).replace(filepath, "");
                 this.placeObject(fileDeserialized, strippedFilePath, result, strippablePath);
@@ -35,7 +35,7 @@ export class ImporterUtil {
         });
 
         await Promise.all(fileProcessingPromises).catch((e) => console.error(e)); // Wait for promises to resolve
-        await this.jsonUtil.writeCacheAsync(); // Execute writing of all of the hashes one single time
+        await this.jsonUtil.writeCache(); // Execute writing of all of the hashes one single time
         return result;
     }
 

--- a/project/src/utils/ImporterUtil.ts
+++ b/project/src/utils/ImporterUtil.ts
@@ -13,8 +13,8 @@ export class ImporterUtil {
     public async loadAsync<T>(
         filepath: string,
         strippablePath = "",
-        onReadCallback: (fileWithPath: string, data: string) => void = () => {},
-        onObjectDeserialized: (fileWithPath: string, object: any) => void = () => {},
+        onReadCallback: (fileWithPath: string, data: string) => Promise<void> = () => Promise.resolve(),
+        onObjectDeserialized: (fileWithPath: string, object: any) => Promise<void> = () => Promise.resolve(),
     ): Promise<T> {
         const result = {} as T;
 
@@ -24,9 +24,9 @@ export class ImporterUtil {
         const fileProcessingPromises = allFiles.map(async (file) => {
             try {
                 const fileData = await this.fileSystem.read(file);
-                onReadCallback(file, fileData);
-                const fileDeserialized = await this.jsonUtil.deserializeWithCacheCheckAsync<any>(fileData, file);
-                onObjectDeserialized(file, fileDeserialized);
+                await onReadCallback(file, fileData);
+                const fileDeserialized = await this.jsonUtil.deserializeWithCacheCheckAsync<any>(fileData, file, false);
+                await onObjectDeserialized(file, fileDeserialized);
                 const strippedFilePath = FileSystem.stripExtension(file).replace(filepath, "");
                 this.placeObject(fileDeserialized, strippedFilePath, result, strippablePath);
             } finally {
@@ -35,31 +35,26 @@ export class ImporterUtil {
         });
 
         await Promise.all(fileProcessingPromises).catch((e) => console.error(e)); // Wait for promises to resolve
+        await this.jsonUtil.writeCacheAsync(); // Execute writing of all of the hashes one single time
         return result;
     }
 
     protected placeObject<T>(fileDeserialized: any, strippedFilePath: string, result: T, strippablePath: string): void {
         const strippedFinalPath = strippedFilePath.replace(strippablePath, "");
-        let temp = result;
         const propertiesToVisit = strippedFinalPath.split("/");
-        for (let i = 0; i < propertiesToVisit.length; i++) {
-            const property = propertiesToVisit[i];
 
-            if (i === propertiesToVisit.length - 1) {
-                temp[property] = fileDeserialized;
+        // Traverse the object structure
+        let current = result;
+
+        for (const [index, property] of propertiesToVisit.entries()) {
+            // If we're at the last property, set the value
+            if (index === propertiesToVisit.length - 1) {
+                current[property] = fileDeserialized;
             } else {
-                if (!temp[property]) {
-                    temp[property] = {};
-                }
-                temp = temp[property];
+                // Ensure the property exists as an object and move deeper
+                current[property] = current[property] || {};
+                current = current[property];
             }
         }
     }
-}
-
-class VisitNode {
-    constructor(
-        public filePath: string,
-        public fileName: string,
-    ) {}
 }

--- a/project/src/utils/JsonUtil.ts
+++ b/project/src/utils/JsonUtil.ts
@@ -211,7 +211,7 @@ export class JsonUtil {
     }
 
     /**
-     * Read contents of json cache and add to class field asynchronously
+     * Read contents of json cache and add to class field
      * @param jsonCachePath Path to cache
      */
     protected async hydrateJsonCache(jsonCachePath: string): Promise<void> {

--- a/project/src/utils/JsonUtil.ts
+++ b/project/src/utils/JsonUtil.ts
@@ -163,7 +163,7 @@ export class JsonUtil {
                     this.fileHashes[filePath] = generatedHash;
 
                     if (writeHashes) {
-                        await this.fileSystem.write(this.jsonCachePath, this.serialize(this.fileHashes, true));
+                        await this.fileSystem.writeJson(this.jsonCachePath, this.fileHashes);
                     }
 
                     savedHash = generatedHash;
@@ -189,7 +189,11 @@ export class JsonUtil {
      * Writes the file hashes to the cache path, to be used manually if writeHashes was set to false on deserializeWithCacheCheck
      */
     public async writeCache(): Promise<void> {
-        await this.fileSystem.write(this.jsonCachePath, this.serialize(this.fileHashes, true));
+        if (!this.fileHashes) {
+            return;
+        }
+
+        await this.fileSystem.writeJson(this.jsonCachePath, this.fileHashes);
     }
 
     /**
@@ -213,7 +217,7 @@ export class JsonUtil {
     protected async hydrateJsonCache(jsonCachePath: string): Promise<void> {
         // Get all file hashes
         if (!this.fileHashes) {
-            this.fileHashes = this.deserialize(await this.fileSystem.read(`${jsonCachePath}`));
+            this.fileHashes = await this.fileSystem.readJson(`${jsonCachePath}`);
         }
     }
 

--- a/project/src/utils/JsonUtil.ts
+++ b/project/src/utils/JsonUtil.ts
@@ -127,19 +127,19 @@ export class JsonUtil {
     }
 
     /**
-     * Take json from file and convert into object asynchronously
+     * Take json from file and convert into object
      * Perform valadation on json during process if json file has not been processed before
      * @param jsonString String to turn into object
      * @param filePath Path to json file being processed
      * @returns A promise that resolves with the object if successful, if not returns undefined
      */
-    public async deserializeWithCacheCheckAsync<T>(
+    public async deserializeWithCacheCheck<T>(
         jsonString: string,
         filePath: string,
         writeHashes = true,
     ): Promise<T | undefined> {
-        await this.ensureJsonCacheExistsAsync(this.jsonCachePath);
-        await this.hydrateJsonCacheAsync(this.jsonCachePath);
+        await this.ensureJsonCacheExists(this.jsonCachePath);
+        await this.hydrateJsonCache(this.jsonCachePath);
 
         // Generate hash of string
         const generatedHash = await this.hashUtil.generateSha1ForDataAsync(jsonString);
@@ -186,9 +186,9 @@ export class JsonUtil {
     }
 
     /**
-     * Writes the file hashes to the cache path, to be used manually if writeHashes was set to false on deserializeWithCacheCheckAsync
+     * Writes the file hashes to the cache path, to be used manually if writeHashes was set to false on deserializeWithCacheCheck
      */
-    public async writeCacheAsync(): Promise<void> {
+    public async writeCache(): Promise<void> {
         await this.fileSystem.write(this.jsonCachePath, this.serialize(this.fileHashes, true));
     }
 
@@ -196,7 +196,7 @@ export class JsonUtil {
      * Create file if nothing found asynchronously
      * @param jsonCachePath path to cache
      */
-    protected async ensureJsonCacheExistsAsync(jsonCachePath: string): Promise<void> {
+    protected async ensureJsonCacheExists(jsonCachePath: string): Promise<void> {
         if (!this.jsonCacheExists) {
             if (!(await this.fileSystem.exists(jsonCachePath))) {
                 // Create empty object at path
@@ -210,7 +210,7 @@ export class JsonUtil {
      * Read contents of json cache and add to class field asynchronously
      * @param jsonCachePath Path to cache
      */
-    protected async hydrateJsonCacheAsync(jsonCachePath: string): Promise<void> {
+    protected async hydrateJsonCache(jsonCachePath: string): Promise<void> {
         // Get all file hashes
         if (!this.fileHashes) {
             this.fileHashes = this.deserialize(await this.fileSystem.read(`${jsonCachePath}`));


### PR DESCRIPTION
This should make every part that uses `loadAsync` asynchronous

The changes I made:
- I ended up creating a new method to make SHA-1 hashes asynchronously, did up some reading up and found that `crypto.createHash` could potentially be blocking.
- Ended up doing some slight code cleanup in `ImporterUtil` to make that helper more readable.
- I changed `deserializeWithCacheCheckAsync` to skip writing files with an extra parameter as it was blocking, this can now be called manually with `writeCacheAsync` (Default behavior of this method stays the same)