### PR TITLE
Default new profile name to launcher username

### DIFF
--- a/project/src/callbacks/ProfileCallbacks.ts
+++ b/project/src/callbacks/ProfileCallbacks.ts
@@ -118,6 +118,12 @@ export class ProfileCallbacks {
      * Handle client/game/profile/nickname/reserved
      */
     public getReservedNickname(url: string, info: IEmptyRequestData, sessionID: string): IGetBodyResponseData<string> {
+        const fullProfile = this.profileHelper.getFullProfile(sessionID);
+        if (fullProfile?.info?.username)
+        {
+            return this.httpResponse.getBody(fullProfile.info.username);
+        }
+
         return this.httpResponse.getBody("SPTarkov");
     }
 


### PR DESCRIPTION
Instead of always naming new profiles "SPTarkov", use the launcher username as the default. 

This improves the UX as you can quickly click through account creation on multiple accounts without needing to remember to re-enter a new profile name for each account