### PR TITLE
Allow FileSystem's writeJson spacing to have more options

### DIFF
--- a/project/src/utils/FileSystem.ts
+++ b/project/src/utils/FileSystem.ts
@@ -167,11 +167,11 @@ export class FileSystem {
      *
      * @param file The file path to write to.
      * @param jsonObject The object to write to the file.
-     * @param indentationSpaces The number of spaces to use for indentation.
+     * @param spacing The number of spaces or string used for spacing of the JSON file.
      * @returns A promise that resolves when the write operation is complete.
      */
-    public async writeJson(file: string, jsonObject: object, indentationSpaces?: 4): Promise<void> {
-        const jsonString = JSON.stringify(jsonObject, null, indentationSpaces);
+    public async writeJson(file: string, jsonObject: object, spacing: string | number = 4): Promise<void> {
+        const jsonString = JSON.stringify(jsonObject, null, spacing);
         return this.write(file, jsonString);
     }
 

--- a/project/src/utils/FileSystemSync.ts
+++ b/project/src/utils/FileSystemSync.ts
@@ -165,11 +165,11 @@ export class FileSystemSync {
      *
      * @param file The file path to write to.
      * @param jsonObject The object to write to the file.
-     * @param indentationSpaces The number of spaces to use for indentation.
+     * @param spacing The number of spaces or string used for spacing of the JSON file.
      * @returns void
      */
-    public writeJson(file: string, jsonObject: object, indentationSpaces?: 4): void {
-        const jsonString = JSON.stringify(jsonObject, null, indentationSpaces);
+    public writeJson(file: string, jsonObject: object, spacing: string | number = 4): void {
+        const jsonString = JSON.stringify(jsonObject, null, spacing);
         this.write(file, jsonString);
     }
 


### PR DESCRIPTION
Does as it says, essentially allows users to fully customize how they want their JSON files written.