### PR TITLE
Add support for 'View Hideout'

### DIFF
--- a/project/src/controllers/GameController.ts
+++ b/project/src/controllers/GameController.ts
@@ -132,7 +132,7 @@ export class GameController {
             //3.9 migrations
             if (fullProfile.spt.version.includes("3.9.") && !fullProfile.spt.migrations["39x"]) {
                 // Check every item has a valid mongoid
-                this.inventoryHelper.validateInventoryUsesMonogoIds(fullProfile.characters.pmc.Inventory.items);
+                this.inventoryHelper.validateInventoryUsesMongoIds(fullProfile.characters.pmc.Inventory.items);
 
                 this.migrate39xProfile(fullProfile);
 

--- a/project/src/controllers/ProfileController.ts
+++ b/project/src/controllers/ProfileController.ts
@@ -1,4 +1,5 @@
 import { PlayerScavGenerator } from "@spt/generators/PlayerScavGenerator";
+import { ItemHelper } from "@spt/helpers/ItemHelper";
 import { ProfileHelper } from "@spt/helpers/ProfileHelper";
 import { IPmcData } from "@spt/models/eft/common/IPmcData";
 import { IMiniProfile } from "@spt/models/eft/launcher/IMiniProfile";
@@ -29,7 +30,8 @@ export class ProfileController {
         @inject("CreateProfileService") protected createProfileService: CreateProfileService,
         @inject("PlayerScavGenerator") protected playerScavGenerator: PlayerScavGenerator,
         @inject("ProfileHelper") protected profileHelper: ProfileHelper,
-    ) {}
+        @inject("ItemHelper") protected itemHelper: ItemHelper,
+    ) { }
 
     /**
      * Handle /launcher/profiles
@@ -210,6 +212,14 @@ export class ProfileController {
         }
         const playerPmc = profile.characters.pmc;
         const playerScav = profile.characters.scav;
+        const hideoutKeys = [...Object.values(playerPmc.Inventory.hideoutAreaStashes), playerPmc.Inventory.hideoutCustomizationStashId];
+
+        const hideoutItems = playerPmc.Inventory.items.filter(x => hideoutKeys.includes(x._id));
+        const itemsToReturn = [];
+        for (const item of hideoutItems) {
+            const foundItems = this.itemHelper.findAndReturnChildrenAsItems(playerPmc.Inventory.items, item._id);
+            itemsToReturn.push(...foundItems);
+        }
 
         return {
             id: playerPmc._id,
@@ -249,6 +259,10 @@ export class ProfileController {
                     overAllCounters: playerScav.Stats.Eft.OverallCounters,
                 },
             },
+            hideout: playerPmc.Hideout,
+            customizationStash: playerPmc.Inventory.hideoutCustomizationStashId,
+            hideoutAreaStashes: playerPmc.Inventory.hideoutAreaStashes,
+            items: itemsToReturn
         };
     }
 

--- a/project/src/models/eft/profile/IGetOtherProfileResponse.ts
+++ b/project/src/models/eft/profile/IGetOtherProfileResponse.ts
@@ -1,4 +1,4 @@
-import { IOverallCounters, ISkills } from "@spt/models/eft/common/tables/IBotBase";
+import { IHideout, IOverallCounters, ISkills } from "@spt/models/eft/common/tables/IBotBase";
 import { IItem } from "@spt/models/eft/common/tables/IItem";
 
 export interface IGetOtherProfileResponse {
@@ -12,6 +12,10 @@ export interface IGetOtherProfileResponse {
     favoriteItems: IItem[];
     pmcStats: IOtherProfileStats;
     scavStats: IOtherProfileStats;
+    hideout: IHideout;
+    hideoutAreaStashes: Record<string, string>;
+    customizationStash: string;
+    items: IItem[];
 }
 
 export interface IOtherProfileInfo {


### PR DESCRIPTION
Adds missing data to the "view profile" endpoint.

NOTE: Causes severe freezes when viewing the hideout, but this happens when loading your own too. I think this is a live issue.