### PR TITLE
Expand filterPlateModsForSlotByLevel to attempt other plate class levels before falling back to default plates

### DIFF
--- a/project/src/generators/BotEquipmentModGenerator.ts
+++ b/project/src/generators/BotEquipmentModGenerator.ts
@@ -334,6 +334,24 @@ export class BotEquipmentModGenerator {
     }
 
     /**
+     * Gets the minimum and maximum plate class levels from an array of plates
+     * @param platePool Pool of plates to sort by armorClass to get min and max
+     * @returns MinMax of armorClass from plate pool
+     */
+    protected getMinMaxArmorPlateClass(platePool: ITemplateItem[]): MinMax {
+        platePool.sort((x, y) => {
+            if (x._props.armorClass < y._props.armorClass) return -1;
+            if (x._props.armorClass > y._props.armorClass) return 1;
+            return 0;
+        });
+
+        return {
+            min: Number(platePool[0]._props.armorClass),
+            max: Number(platePool[platePool.length - 1]._props.armorClass),
+        };
+    }
+
+    /**
      * Add mods to a weapon using the provided mod pool
      * @param sessionId Session id
      * @param request Data used to generate the weapon

--- a/project/src/generators/BotEquipmentModGenerator.ts
+++ b/project/src/generators/BotEquipmentModGenerator.ts
@@ -7,6 +7,7 @@ import { PresetHelper } from "@spt/helpers/PresetHelper";
 import { ProbabilityHelper } from "@spt/helpers/ProbabilityHelper";
 import { ProfileHelper } from "@spt/helpers/ProfileHelper";
 import { WeightedRandomHelper } from "@spt/helpers/WeightedRandomHelper";
+import { MinMax } from "@spt/models/common/MinMax";
 import { IPreset } from "@spt/models/eft/common/IGlobals";
 import { IMods, IModsChances } from "@spt/models/eft/common/tables/IBotType";
 import { IItem } from "@spt/models/eft/common/tables/IItem";

--- a/project/src/generators/BotEquipmentModGenerator.ts
+++ b/project/src/generators/BotEquipmentModGenerator.ts
@@ -317,7 +317,6 @@ export class BotEquipmentModGenerator {
 
                 // If no valid plate class is found in 3 tries then attempt default plates
                 if (fitPlateIntoArmorAttempts >= maxTries) {
-                    console.log(JSON.stringify(platesOfDesiredLevel));
                     this.logger.debug(
                         `Plate filter was too restrictive for armor: ${armorItem._name} ${armorItem._id}, unable to find plates of level: ${chosenArmorPlateLevel}. Using mod items default plate`,
                     );

--- a/project/src/generators/BotEquipmentModGenerator.ts
+++ b/project/src/generators/BotEquipmentModGenerator.ts
@@ -302,12 +302,13 @@ export class BotEquipmentModGenerator {
             // Attempt to increase plate class level to attempt getting minimum plate level useable based on original selection
             for (let i = 0; i < maxTries; i++) {
                 chosenArmorPlateLevel = (Number.parseInt(chosenArmorPlateLevel) + 1).toString();
-                platesOfDesiredLevel = platesFromDb.filter((item) => item._props.armorClass === chosenArmorPlateLevel);
 
-                // If new chosen plate class is higher than max, then set to min and try again
+                // If new chosen plate class is higher than max, then set to min and check if valid
                 if (Number(chosenArmorPlateLevel) > minMaxArmorPlateClass.max) {
                     chosenArmorPlateLevel = minMaxArmorPlateClass.min.toString();
                 }
+
+                platesOfDesiredLevel = platesFromDb.filter((item) => item._props.armorClass === chosenArmorPlateLevel);
 
                 fitPlateIntoArmorAttempts++;
                 // Break loop if valid plate class is found


### PR DESCRIPTION
Instead of automatically falling back to default plates, this change will allow the bot to attempt the next level higher armor class up to 3 times before falling back to defaults. 

Through testing this prevents falling back to defaults roughly 95% of the time and retains the ability to roll the lowest level available armor class if the initial armor class level selected is too low for the armor.