### PR TITLE
1090 Prestige 1 rewards re-locked after prestiging a 2nd time.

### DIFF
--- a/project/src/controllers/PrestigeController.ts
+++ b/project/src/controllers/PrestigeController.ts
@@ -116,12 +116,16 @@ export class PrestigeController {
 
         const indexOfPrestigeObtained = Math.min(createRequest.sptForcePrestigeLevel - 1, 1); // Index starts at 0
         // Assumes Prestige data is in descending order
-        const matchingPrestigeData = this.databaseService.getTemplates().prestige.elements[indexOfPrestigeObtained];
+        const currentPrestigeData = this.databaseService.getTemplates().prestige.elements[indexOfPrestigeObtained];
+        const prestigeRewards = this.databaseService
+            .getTemplates()
+            .prestige.elements.slice(0, indexOfPrestigeObtained + 1)
+            .flatMap((prestige) => prestige.rewards);
 
-        this.addPrestigeRewardsToProfile(sessionId, newProfile, matchingPrestigeData.rewards);
+        this.addPrestigeRewardsToProfile(sessionId, newProfile, prestigeRewards);
 
         // Flag profile as having achieved this prestige level
-        newProfile.characters.pmc.Prestige[matchingPrestigeData.id] = this.timeUtil.getTimestamp();
+        newProfile.characters.pmc.Prestige[currentPrestigeData.id] = this.timeUtil.getTimestamp();
 
         // Copy transferred items
         for (const transferRequest of request) {


### PR DESCRIPTION
https://github.com/sp-tarkov/server/issues/1090
Fix for this issue, by awarding all Prestige rewards up to and including the current prestige level
