### PR TITLE
Fix launcher thinking profile deletion failed

### DIFF
--- a/project/src/servers/SaveServer.ts
+++ b/project/src/servers/SaveServer.ts
@@ -221,6 +221,6 @@ export class SaveServer {
 
         await this.fileSystem.remove(file);
 
-        return !this.fileSystem.exists(file);
+        return !(await this.fileSystem.exists(file));
     }
 }


### PR DESCRIPTION
The launcher currently thinks all profile deletions fail. This should fix it

Testing:
- Create new profile (No need to log in)
- Delete new profile

Reasoning:
We need to invert the returned value of the `exists` call, which means we need to actually await it instead of trying to return the inverse of the promise
I did a quick search over the codebase for other places we have Promise<boolean> return types, and didn't see any other similar issues elsewhere