### PR TITLE
Small saveserver changes

### DIFF
--- a/project/src/servers/SaveServer.ts
+++ b/project/src/servers/SaveServer.ts
@@ -72,12 +72,19 @@ export class SaveServer {
      */
     public async save(): Promise<void> {
         const timer = new Timer();
+        let savedProfiles = 0;
+
         for (const [sessionId] of this.profiles) {
-            await this.saveProfile(sessionId);
+            try {
+                await this.saveProfile(sessionId);
+                savedProfiles++;
+            } catch (error) {
+                this.logger.error(`Could not save profile ${sessionId} | ${error}`);
+            }
         }
-        const profileCount = this.profiles.size;
+
         this.logger.debug(
-            `Saving ${profileCount} profile${profileCount > 1 ? "s" : ""} took ${timer.getTime("ms")}ms`,
+            `Saving ${savedProfiles} profile${savedProfiles > 1 ? "s" : ""} took ${timer.getTime("ms")}ms`,
             false,
         );
     }


### PR DESCRIPTION
- Adds a saveguard to the current profile being saved to prevent it from being called again for a save if one is already underway, this is only ever possible in my testing to happen on certain race conditions where a user might quit the game at the same time as the server is saving, none the less it's better if this is only processed one-time
- Wraps current timed saves in a try-catch so that if one profile errors out during saving this does not completely stop the method from running.