### PR TITLE
Fix mod sort order

### DIFF
--- a/project/src/utils/FileSystem.ts
+++ b/project/src/utils/FileSystem.ts
@@ -363,6 +363,7 @@ export class FileSystem {
                 .map((dirent) => path.join(dirent.parentPath, dirent.name).replace(/\\/g, "/"))
                 // Optionally remove the input directory from the path.
                 .map((dir) => (includeInputDir ? dir : dir.replace(directoryNormalized, "")))
+                .sort()
         );
     }
 }

--- a/project/src/utils/FileSystemSync.ts
+++ b/project/src/utils/FileSystemSync.ts
@@ -353,6 +353,7 @@ export class FileSystemSync {
                 .map((dirent) => path.join(dirent.parentPath, dirent.name).replace(/\\/g, "/"))
                 // Optionally remove the input directory from the path.
                 .map((dir) => (includeInputDir ? dir : dir.replace(directoryNormalized, "")))
+                .sort()
         );
     }
 }


### PR DESCRIPTION
Make sure mods are in proper alphabetical order, fsExtra is throwing special characters last for some reason