### PR TITLE
Use Bot.Info.Level to generateInventory

### DIFF
--- a/project/src/generators/BotGenerator.ts
+++ b/project/src/generators/BotGenerator.ts
@@ -260,7 +260,7 @@ export class BotGenerator {
             botJsonTemplate,
             botRoleLowercase,
             botGenerationDetails.isPmc,
-            botLevel.level,
+            bot.Info.Level,
             bot.Info.GameVersion,
         );
 


### PR DESCRIPTION
If you alter a bots level after the level has been selected, but before the inventory is generated then the inventory will generate using the original level instead of it's new level. 

(Say you wanted to update the bot's level in the GameVersionAndCategory or Appearance method for some reason)

This PR fixes it so the bots level at the time of generating the inventory is passed accurately.