### PR TITLE
Fix `Insured item...is null` error

### DIFF
--- a/project/src/services/LocationLifecycleService.ts
+++ b/project/src/services/LocationLifecycleService.ts
@@ -1004,7 +1004,7 @@ export class LocationLifecycleService {
             const mappedItems = this.insuranceService.mapInsuredItemsToTrader(
                 sessionId,
                 request.lostInsuredItems,
-                request.results.profile,
+                preRaidPmcProfile,
             );
 
             // Is possible to have items in lostInsuredItems but removed before reaching mappedItems

--- a/project/src/services/ProfileFixerService.ts
+++ b/project/src/services/ProfileFixerService.ts
@@ -67,6 +67,7 @@ export class ProfileFixerService {
         this.removeOrphanedQuests(pmcProfile);
         this.verifyQuestProductionUnlocks(pmcProfile);
         this.fixFavorites(pmcProfile);
+        this.fixOrphanedInsurance(pmcProfile);
 
         if (pmcProfile.Hideout) {
             this.addHideoutEliteSlots(pmcProfile);
@@ -404,6 +405,21 @@ export class ProfileFixerService {
 
             pmcProfile.Inventory.favoriteItems = correctedFavorites ?? [];
         }
+    }
+
+    /**
+     * Remove any entries from `pmcProfile.InsuredItems` that do not have a corresponding
+     * `pmcProfile.Inventory.items` entry
+     * @param pmcProfile 
+     */
+    protected fixOrphanedInsurance(pmcProfile: IPmcData): void {
+        const startTime = performance.now();
+        pmcProfile.InsuredItems = pmcProfile.InsuredItems.filter((insuredItem) => {
+            // Check if the player inventory contains this item
+            return pmcProfile.Inventory.items.some((item) => item._id === insuredItem.itemId);
+        });
+        const duration = performance.now() - startTime;
+        console.log(`Took ${duration}ms to filter insurance`);
     }
 
     /**

--- a/project/src/services/ProfileFixerService.ts
+++ b/project/src/services/ProfileFixerService.ts
@@ -413,13 +413,10 @@ export class ProfileFixerService {
      * @param pmcProfile 
      */
     protected fixOrphanedInsurance(pmcProfile: IPmcData): void {
-        const startTime = performance.now();
         pmcProfile.InsuredItems = pmcProfile.InsuredItems.filter((insuredItem) => {
             // Check if the player inventory contains this item
             return pmcProfile.Inventory.items.some((item) => item._id === insuredItem.itemId);
         });
-        const duration = performance.now() - startTime;
-        console.log(`Took ${duration}ms to filter insurance`);
     }
 
     /**


### PR DESCRIPTION
- `mapInsuredItemsToTrader` should be using the pre-raid PMC profile, as the request profile isn't copied over after this method is run
- Add a new profileFixer method to clean up old orphaned InsuredItems