### PR TITLE
Fix typos (re)qeust -> (re)quest

### DIFF
--- a/project/src/controllers/HideoutController.ts
+++ b/project/src/controllers/HideoutController.ts
@@ -428,7 +428,7 @@ export class HideoutController {
      * Handle HideoutPutItemsInAreaSlots
      * Create item in hideout slot item array, remove item from player inventory
      * @param pmcData Profile data
-     * @param addItemToHideoutRequest reqeust from client to place item in area slot
+     * @param addItemToHideoutRequest request from client to place item in area slot
      * @param sessionID Session id
      * @returns IItemEventRouterResponse object
      */

--- a/project/src/controllers/InventoryController.ts
+++ b/project/src/controllers/InventoryController.ts
@@ -522,7 +522,7 @@ export class InventoryController {
      * Bind an inventory item to the quick access menu at bottom of player screen
      * Handle bind event
      * @param pmcData Player profile
-     * @param bindRequest Reqeust object
+     * @param bindRequest Request object
      * @param sessionID Session id
      * @returns IItemEventRouterResponse
      */

--- a/project/src/controllers/ProfileController.ts
+++ b/project/src/controllers/ProfileController.ts
@@ -97,7 +97,7 @@ export class ProfileController {
 
     /**
      * Handle client/game/profile/create
-     * @param info Client reqeust object
+     * @param info Client request object
      * @param sessionID Player id
      * @returns Profiles _id value
      */

--- a/project/src/controllers/QuestController.ts
+++ b/project/src/controllers/QuestController.ts
@@ -158,7 +158,7 @@ export class QuestController {
         for (const condition of questConditions) {
             if (pmcData.TaskConditionCounters[condition.id]) {
                 this.logger.error(
-                    `Unable to add new task condition counter: ${condition.conditionType} for qeust: ${questId} to profile: ${pmcData.sessionId} as it already exists:`,
+                    `Unable to add new task condition counter: ${condition.conditionType} for quest: ${questId} to profile: ${pmcData.sessionId} as it already exists:`,
                 );
             }
 
@@ -476,7 +476,7 @@ export class QuestController {
     /**
      * Handle /client/game/profile/items/moving - QuestFail
      * @param pmcData Pmc profile
-     * @param request Fail qeust request
+     * @param request Fail quest request
      * @param sessionID Session id
      * @returns IItemEventRouterResponse
      */


### PR DESCRIPTION
This fixes a few typos in doc comments and one log message I noticed when playing on 3.10.5 (restarting The Guide and Psycho Sniper).
The typo remains in a class name, but I'll leave it to someone with more authority to change it unless requested.

https://github.com/sp-tarkov/server/blob/9f494859bd7d9cb18be3f276ccf655a0ff4dfd67/project/src/models/eft/trade/IProcessRagfairTradeRequestData.ts#L12