### PR TITLE
Refactor RaidTimeAdjustment to work as server authoritative

### DIFF
--- a/project/src/controllers/GameController.ts
+++ b/project/src/controllers/GameController.ts
@@ -542,11 +542,6 @@ export class GameController {
      * Handle singleplayer/settings/getRaidTime
      */
     public getRaidTime(sessionId: string, request: IGetRaidTimeRequest): IGetRaidTimeResponse {
-        // Set interval times to in-raid value
-        this.ragfairConfig.runIntervalSeconds = this.ragfairConfig.runIntervalValues.inRaid;
-
-        this.hideoutConfig.runIntervalSeconds = this.hideoutConfig.runIntervalValues.inRaid;
-
         return this.raidTimeAdjustmentService.getRaidAdjustments(sessionId, request);
     }
 

--- a/project/src/models/eft/game/IGetRaidTimeResponse.ts
+++ b/project/src/models/eft/game/IGetRaidTimeResponse.ts
@@ -1,13 +1,4 @@
 export interface IGetRaidTimeResponse {
-    RaidTimeMinutes: number;
     NewSurviveTimeSeconds?: number;
     OriginalSurvivalTimeSeconds: number;
-    ExitChanges: ExtractChange[];
-}
-
-export interface ExtractChange {
-    Name: string;
-    MinTime?: number;
-    MaxTime?: number;
-    Chance?: number;
 }

--- a/project/src/models/spt/location/IRaidChanges.ts
+++ b/project/src/models/spt/location/IRaidChanges.ts
@@ -5,4 +5,19 @@ export interface IRaidChanges {
     staticLootPercent: number;
     /** How many seconds into the raid is the player simulated to spawn in at */
     simulatedRaidStartSeconds: number;
+    /** How many minutes are in the raid total */
+    raidTimeMinutes: number;
+    /** The new number of seconds required to avoid a run through */
+    newSurviveTimeSeconds?: number;
+    /** The original number of seconds required to avoid a run through */
+    originalSurvivalTimeSeconds: number;
+    /** Any changes required to the extract list */
+    exitChanges: ExtractChange[];
+}
+
+export interface ExtractChange {
+    Name: string;
+    MinTime?: number;
+    MaxTime?: number;
+    Chance?: number;
 }

--- a/project/src/services/PostDbLoadService.ts
+++ b/project/src/services/PostDbLoadService.ts
@@ -89,8 +89,6 @@ export class PostDbLoadService {
             this.removeExistingPmcWaves();
         }
 
-        this.pmcWaveGenerator.applyWaveChangesToAllMaps();
-
         if (this.locationConfig.addCustomBotWavesToMaps) {
             this.customLocationWaveService.applyWaveChangesToAllMaps();
         }

--- a/project/src/services/RaidTimeAdjustmentService.ts
+++ b/project/src/services/RaidTimeAdjustmentService.ts
@@ -57,22 +57,22 @@ export class RaidTimeAdjustmentService {
         mapBase.EscapeTimeLimit = raidAdjustments.raidTimeMinutes;
 
         // Adjust map exits
-        raidAdjustments.exitChanges.forEach(exitChange => {
-            const exitToChange = mapBase.exits.find(exit => exit.Name === exitChange.Name);
+        raidAdjustments.exitChanges.forEach((exitChange) => {
+            const exitToChange = mapBase.exits.find((exit) => exit.Name === exitChange.Name);
             if (!exitToChange) {
                 this.logger.debug(`Exit with Id: ${exitChange.Name} not found, skipping`);
                 return;
             }
 
-            if (typeof exitChange.Chance !== 'undefined') {
+            if (typeof exitChange.Chance !== "undefined") {
                 exitToChange.Chance = exitChange.Chance;
             }
 
-            if (typeof exitChange.MinTime !== 'undefined') {
+            if (typeof exitChange.MinTime !== "undefined") {
                 exitToChange.MinTime = exitChange.MinTime;
             }
 
-            if (typeof exitChange.MaxTime !== 'undefined') {
+            if (typeof exitChange.MaxTime !== "undefined") {
                 exitToChange.MaxTime = exitChange.MaxTime;
             }
         });
@@ -178,7 +178,7 @@ export class RaidTimeAdjustmentService {
             originalSurvivalTimeSeconds: result.OriginalSurvivalTimeSeconds,
             exitChanges: [],
             newSurviveTimeSeconds: result.NewSurviveTimeSeconds,
-            simulatedRaidStartSeconds: 0
+            simulatedRaidStartSeconds: 0,
         };
 
         if (mapSettings.reduceLootByPercent) {

--- a/project/src/services/RaidTimeAdjustmentService.ts
+++ b/project/src/services/RaidTimeAdjustmentService.ts
@@ -3,14 +3,14 @@ import { ContextVariableType } from "@spt/context/ContextVariableType";
 import { WeightedRandomHelper } from "@spt/helpers/WeightedRandomHelper";
 import { ILocationBase } from "@spt/models/eft/common/ILocationBase";
 import { IGetRaidTimeRequest } from "@spt/models/eft/game/IGetRaidTimeRequest";
-import { ExtractChange, IGetRaidTimeResponse } from "@spt/models/eft/game/IGetRaidTimeResponse";
+import { IGetRaidTimeResponse } from "@spt/models/eft/game/IGetRaidTimeResponse";
 import { ConfigTypes } from "@spt/models/enums/ConfigTypes";
 import {
     ILocationConfig,
     ILootMultiplier,
     IScavRaidTimeLocationSettings,
 } from "@spt/models/spt/config/ILocationConfig";
-import { IRaidChanges } from "@spt/models/spt/location/IRaidChanges";
+import { ExtractChange, IRaidChanges } from "@spt/models/spt/location/IRaidChanges";
 import type { ILogger } from "@spt/models/spt/utils/ILogger";
 import { ConfigServer } from "@spt/servers/ConfigServer";
 import { DatabaseService } from "@spt/services/DatabaseService";
@@ -39,17 +39,47 @@ export class RaidTimeAdjustmentService {
      * @param mapBase Map to adjust
      */
     public makeAdjustmentsToMap(raidAdjustments: IRaidChanges, mapBase: ILocationBase): void {
-        this.logger.debug(
-            `Adjusting dynamic loot multipliers to ${raidAdjustments.dynamicLootPercent}% and static loot multipliers to ${raidAdjustments.staticLootPercent}% of original`,
-        );
+        if (raidAdjustments.dynamicLootPercent < 100 || raidAdjustments.staticLootPercent < 100) {
+            this.logger.debug(
+                `Adjusting dynamic loot multipliers to ${raidAdjustments.dynamicLootPercent}% and static loot multipliers to ${raidAdjustments.staticLootPercent}% of original`,
+            );
+        }
 
         // Change loot multipler values before they're used below
-        this.adjustLootMultipliers(this.locationConfig.looseLootMultiplier, raidAdjustments.dynamicLootPercent);
-        this.adjustLootMultipliers(this.locationConfig.staticLootMultiplier, raidAdjustments.staticLootPercent);
+        if (raidAdjustments.dynamicLootPercent < 100) {
+            this.adjustLootMultipliers(this.locationConfig.looseLootMultiplier, raidAdjustments.dynamicLootPercent);
+        }
+        if (raidAdjustments.staticLootPercent < 100) {
+            this.adjustLootMultipliers(this.locationConfig.staticLootMultiplier, raidAdjustments.staticLootPercent);
+        }
 
+        // Adjust the escape time limit
+        mapBase.EscapeTimeLimit = raidAdjustments.raidTimeMinutes;
+
+        // Adjust map exits
+        raidAdjustments.exitChanges.forEach(exitChange => {
+            const exitToChange = mapBase.exits.find(exit => exit.Name === exitChange.Name);
+            if (!exitToChange) {
+                this.logger.debug(`Exit with Id: ${exitChange.Name} not found, skipping`);
+                return;
+            }
+
+            if (typeof exitChange.Chance !== 'undefined') {
+                exitToChange.Chance = exitChange.Chance;
+            }
+
+            if (typeof exitChange.MinTime !== 'undefined') {
+                exitToChange.MinTime = exitChange.MinTime;
+            }
+
+            if (typeof exitChange.MaxTime !== 'undefined') {
+                exitToChange.MaxTime = exitChange.MaxTime;
+            }
+        });
+
+        // Make alterations to bot spawn waves now player is simulated spawning later
         const mapSettings = this.getMapSettings(mapBase.Id);
         if (mapSettings.adjustWaves) {
-            // Make alterations to bot spawn waves now player is simulated spawning later
             this.adjustWaves(mapBase, raidAdjustments);
         }
     }
@@ -102,8 +132,6 @@ export class RaidTimeAdjustmentService {
 
         // Prep result object to return
         const result: IGetRaidTimeResponse = {
-            RaidTimeMinutes: baseEscapeTimeMinutes,
-            ExitChanges: [],
             NewSurviveTimeSeconds: undefined,
             OriginalSurvivalTimeSeconds: globals.config.exp.match_end.survived_seconds_requirement,
         };
@@ -136,32 +164,40 @@ export class RaidTimeAdjustmentService {
         // Time player spawns into the raid if it was online
         const simulatedRaidStartTimeMinutes = baseEscapeTimeMinutes - newRaidTimeMinutes;
 
-        if (mapSettings.reduceLootByPercent) {
-            // Store time reduction percent in app context so loot gen can pick it up later
-            this.applicationContext.addValue(ContextVariableType.RAID_ADJUSTMENTS, {
-                dynamicLootPercent: Math.max(raidTimeRemainingPercent, mapSettings.minDynamicLootPercent),
-                staticLootPercent: Math.max(raidTimeRemainingPercent, mapSettings.minStaticLootPercent),
-                simulatedRaidStartSeconds: simulatedRaidStartTimeMinutes * 60,
-            });
-        }
-
-        // Update result object with new time
-        result.RaidTimeMinutes = newRaidTimeMinutes;
-
-        this.logger.debug(
-            `Reduced: ${request.Location} raid time by: ${chosenRaidReductionPercent}% to ${newRaidTimeMinutes} minutes`,
-        );
-
         // Calculate how long player needs to be in raid to get a `survived` extract status
         result.NewSurviveTimeSeconds = Math.max(
             result.OriginalSurvivalTimeSeconds - (baseEscapeTimeMinutes - newRaidTimeMinutes) * 60,
             0,
         );
 
+        // State that we'll pass to loot generation
+        const raidChanges: IRaidChanges = {
+            dynamicLootPercent: 100,
+            staticLootPercent: 100,
+            raidTimeMinutes: newRaidTimeMinutes,
+            originalSurvivalTimeSeconds: result.OriginalSurvivalTimeSeconds,
+            exitChanges: [],
+            newSurviveTimeSeconds: result.NewSurviveTimeSeconds,
+            simulatedRaidStartSeconds: 0
+        };
+
+        if (mapSettings.reduceLootByPercent) {
+            raidChanges.dynamicLootPercent = Math.max(raidTimeRemainingPercent, mapSettings.minDynamicLootPercent);
+            raidChanges.staticLootPercent = Math.max(raidTimeRemainingPercent, mapSettings.minStaticLootPercent);
+            raidChanges.simulatedRaidStartSeconds = simulatedRaidStartTimeMinutes * 60;
+        }
+
+        this.logger.debug(
+            `Reduced: ${request.Location} raid time by: ${chosenRaidReductionPercent}% to ${newRaidTimeMinutes} minutes`,
+        );
+
         const exitAdjustments = this.getExitAdjustments(mapBase, newRaidTimeMinutes);
         if (exitAdjustments) {
-            result.ExitChanges.push(...exitAdjustments);
+            raidChanges.exitChanges.push(...exitAdjustments);
         }
+
+        // Store state to use in loot generation
+        this.applicationContext.addValue(ContextVariableType.RAID_ADJUSTMENTS, raidChanges);
 
         return result;
     }


### PR DESCRIPTION
- Move ragfair and hideout `runIntervalSeconds` settings to `startLocalRaid`
- Move pmcWaveGenerator to be run per-map instead of per session
- Refactor RaidTimeAdjustmentService.makeAdjustmentsToMap to handle most of the stuff previously handled in the client patch
- Change getRaidAdjustments to only return the survival time, and store all other data for use in loot generation