### PR TITLE
Safer profile saving handling

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -34,6 +34,7 @@
         "gen:productionquests": "tsx ./src/tools/ProductionQuestsGen/ProductionQuestsGenProgram.ts"
     },
     "dependencies": {
+        "async-mutex": "^0.5.0",
         "atomically": "2.0.3",
         "fs-extra": "11.2.0",
         "i18n": "0.15.1",


### PR DESCRIPTION
Handles this more safely by making each call to this wait for a lock to be released first, rather than throwing an error that might not be handled everywhere this method is called.