### PR TITLE
Weighted compatible ammo fix

### DIFF
--- a/project/src/generators/BotWeaponGenerator.ts
+++ b/project/src/generators/BotWeaponGenerator.ts
@@ -549,7 +549,7 @@ export class BotWeaponGenerator {
     ): string {
         const desiredCaliber = this.getWeaponCaliber(weaponTemplate);
 
-        const cartridgePoolForWeapon = cartridgePool[desiredCaliber];
+        let cartridgePoolForWeapon = cartridgePool[desiredCaliber];
         if (!cartridgePoolForWeapon || cartridgePoolForWeapon?.length === 0) {
             this.logger.debug(
                 this.localisationService.getText("bot-no_caliber_data_for_weapon_falling_back_to_default", {
@@ -578,9 +578,28 @@ export class BotWeaponGenerator {
             }
         }
 
+        // If no compatible cartridges found still, get caliber data from magazine in weapon template
         if (Object.keys(compatibleCartridges).length === 0) {
-            // No compatible cartridges, use default
-            return weaponTemplate._props.defAmmo;
+            // Get cartridges from the weapons first magazine in filters
+            const compatibleCartridgesInMagazine = this.getCompatibleCartridgesFromMagazineTemplate(weaponTemplate);
+            if (compatibleCartridgesInMagazine.length === 0) {
+                // No compatible cartridges found in magazine, use default
+                return weaponTemplate._props.defAmmo;
+            }
+            // Get the caliber data from the first compatible round in the magazine
+            const magazineCaliberData = this.itemHelper.getItem(compatibleCartridgesInMagazine[0])[1]._props.Caliber;
+            cartridgePoolForWeapon = cartridgePool[magazineCaliberData];
+
+            for (const cartridge of Object.keys(cartridgePoolForWeapon)) {
+                if (compatibleCartridgesInMagazine.includes(cartridge)) {
+                    compatibleCartridges[cartridge] = cartridgePoolForWeapon[cartridge];
+                }
+            }
+
+            // Nothing found after also checking magazines, return default ammo
+            if (Object.keys(compatibleCartridges).length === 0) {
+                return weaponTemplate._props.defAmmo;
+            }
         }
 
         return this.weightedRandomHelper.getWeightedValue<string>(compatibleCartridges);
@@ -606,6 +625,27 @@ export class BotWeaponGenerator {
                 // None found, try the cartridges array
                 cartridges = magazineTemplate[1]._props.Cartridges[0]?._props.filters[0].Filter;
             }
+        }
+
+        return cartridges;
+    }
+
+    /**
+     * Get the cartridge ids from a weapon's magazine template that work with the weapon
+     * @param weaponTemplate Weapon db template to get magazine cartridges for
+     * @returns Array of cartridge tpls
+     */
+    protected getCompatibleCartridgesFromMagazineTemplate(weaponTemplate: ITemplateItem): string[] {
+        // Get the first magazine's template from the weapon
+        const magazineSlot = weaponTemplate._props.Slots.find((slot) => slot._name === "mod_magazine");
+        const magazineTemplate = this.itemHelper.getItem(magazineSlot._props.filters[0].Filter[0]);
+
+        // Get the first slots array of cartridges
+        let cartridges = magazineTemplate[1]._props.Slots[0]?._props.filters[0].Filter;
+        if (!cartridges) {
+            // Normal magazines
+            // None found, try the cartridges array
+            cartridges = magazineTemplate[1]._props.Cartridges[0]?._props.filters[0].Filter;
         }
 
         return cartridges;

--- a/project/src/generators/BotWeaponGenerator.ts
+++ b/project/src/generators/BotWeaponGenerator.ts
@@ -578,7 +578,7 @@ export class BotWeaponGenerator {
             }
         }
 
-        if (!compatibleCartridges) {
+        if (Object.keys(compatibleCartridges).length === 0) {
             // No compatible cartridges, use default
             return weaponTemplate._props.defAmmo;
         }


### PR DESCRIPTION
One commit is to fix the check that is always skipped because it's an object and not an array

Secondarily includes a commit to also check the magazine data (in case it's a modded weapon that incorrectly clones a weapon from a different caliber, without updating the data for default ammo)