### PR TITLE
Fix buy_price_coef inversion

### DIFF
--- a/project/src/helpers/TraderHelper.ts
+++ b/project/src/helpers/TraderHelper.ts
@@ -504,7 +504,8 @@ export class TraderHelper {
             // Get loyalty level details player has achieved with this trader
             // Uses lowest loyalty level as this function is used before a player has logged into server
             // We have no idea what player loyalty is with traders
-            const traderBuyBackPricePercent = traderBase.loyaltyLevels[0].buy_price_coef;
+            // buy_price_coef is the inverse percentage, must subtract from 100 to get proper buyback percent
+            const traderBuyBackPricePercent = 100 - traderBase.loyaltyLevels[0].buy_price_coef;
 
             const itemHandbookPrice = this.handbookHelper.getTemplatePrice(tpl);
             const priceTraderBuysItemAt = Math.round(


### PR DESCRIPTION
buy_price_coef isn't a direct percentage for their buyback value, it's an inverse percentage

If it is 30, then their buyback rate is 70% of the handbook, not 30%