### PR TITLE
Fix bundle loading 

### DIFF
--- a/project/src/utils/FileSystem.ts
+++ b/project/src/utils/FileSystem.ts
@@ -146,6 +146,16 @@ export class FileSystem {
     }
 
     /**
+     * Reads a file as raw data and returns the contents as a Buffer.
+     * 
+     * @param file The file path to read.
+     * @returns A promise that resolves with the raw file contents as a Buffer.
+     */
+    public readRaw(file: string): Promise<Buffer> {
+        return atomicallyRead(file);
+    }
+
+    /**
      * Writes data to a file, overwriting if the file already exists. If the parent directory does not exist, it's
      * created. File must be a file path (a buffer or a file descriptor is not allowed).
      *

--- a/project/src/utils/FileSystemSync.ts
+++ b/project/src/utils/FileSystemSync.ts
@@ -144,6 +144,16 @@ export class FileSystemSync {
     }
 
     /**
+     * Reads a file as raw data and returns the contents as a Buffer.
+     * 
+     * @param file The file path to read.
+     * @returns The raw file contents as a Buffer.
+     */
+    public readRaw(file: string): Buffer {
+        return atomicallyReadSync(file);
+    }
+
+    /**
      * Writes data to a file, overwriting if the file already exists. If the parent directory does not exist, it's
      * created. File must be a file path (a buffer or a file descriptor is not allowed).
      *

--- a/project/src/utils/HashUtil.ts
+++ b/project/src/utils/HashUtil.ts
@@ -38,7 +38,7 @@ export class HashUtil {
     }
 
     public generateCRC32ForFile(filePath: string): number {
-        return crc32(this.fileSystemSync.read(filePath));
+        return crc32(this.fileSystemSync.readRaw(filePath));
     }
     /**
      * Create a hash for the data parameter


### PR DESCRIPTION
Fix bundle loading by reading the bundle as raw data instead of UTF8 data before CRC32ing it
Using .read() results in a CRC difference compared to the client