### PR TITLE
Prevent UBGLs from generating patron_in_weapon during mod generation

### DIFF
--- a/project/src/generators/BotEquipmentModGenerator.ts
+++ b/project/src/generators/BotEquipmentModGenerator.ts
@@ -467,6 +467,14 @@ export class BotEquipmentModGenerator {
                 continue;
             }
 
+            // If the parent is a UBGL, the patron_in_weapon will be generated later - so skip it for now
+            if (
+                modSlot === "patron_in_weapon" &&
+                this.itemHelper.isOfBaseclass(request.parentTemplate._id, BaseClasses.UBGL)
+            ) {
+                continue;
+            }
+
             // Check spawn chance of mod
             const modSpawnResult = this.shouldModBeSpawned(
                 modsParentSlot,


### PR DESCRIPTION
Validated that this fixes bots that have data for UBGLs, instead of generating and adding a "patron_in_weapon" during mod generation, skip it since it's already added later at the end of weapon generation.

This will only skip that slot, just in case later BSG adds additional slots to UBGLs. If they do, or add additional chamber names - it would be worth moving this to its own check method